### PR TITLE
chore: bump to 0.37.1 to release lodash security fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arianee/arianee-abi",
-  "version": "0.37.0",
+  "version": "0.37.1",
   "description": "abi definition of Arianee and typescript declaration files",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary
- Bumps version 0.37.0 → 0.37.1
- The lodash upgrade to 4.18.1 (commit b289d58) was merged to master but never released on npm
- Publishing this version will resolve CVE-2026-4800 (HIGH, CVSS 8.1) downstream in all consumers

## Downstream impact
This package is consumed by `@arianee/arianee-access-token` and `@arianee/arianee-privacy-gateway-client`, which are used in:
- ArianeeBrandDataHub
- link-resolver
- wallet-api
- pairing-web-app
- arianee-sdk (root)

## Follow-up
After merge, run `npm publish` to release 0.37.1 on npm, then downstream packages need to bump their `@arianee/arianee-abi` dep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)