### PR TITLE
fix: restore build in publish workflow via prepack hook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@arianee/arianee-abi",
-  "version": "0.37.0",
+  "version": "0.37.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@arianee/arianee-abi",
-      "version": "0.37.0",
+      "version": "0.37.2",
       "license": "ISC",
       "dependencies": {
         "bn": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arianee/arianee-abi",
-  "version": "0.37.1",
+  "version": "0.37.2",
   "description": "abi definition of Arianee and typescript declaration files",
   "publishConfig": {
     "access": "public"
@@ -20,7 +20,7 @@
     "_generateEthers6_v1_6": "typechain --target ethers-v6 --out-dir ./ethers6/v1_6 './abi/json/V1_6/*.json'",
     "minify": "node ./minify.js",
     "build": "npm run generate && npm run minify",
-    "prepublish": "tsc"
+    "prepack": "tsc"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
## Context
\`@arianee/arianee-abi@0.37.1\` was published earlier today but its tarball was missing the \`dist/\` folder (174 files vs ~426 expected), breaking all downstream consumers with errors like:

\`\`\`
Cannot find module '@arianee/arianee-abi/dist/ethers6/v1_5'
\`\`\`

## Root cause
The \`prepublish\` npm lifecycle script is deprecated and no longer runs on \`npm publish\` in modern npm (only on \`npm install\` with no args).

## Fix
- Switch to \`prepack\` hook which runs on both \`npm pack\` and \`npm publish\`
- Bump to 0.37.2 — \`0.37.1\` has been deprecated on npm ("Broken build — use 0.37.2 instead")

## Verification
\`npm publish --dry-run\` produces 426 files (including \`dist/ethers6/\`), matching 0.37.0 shape.

\`@arianee/arianee-abi@0.37.2\` has already been published to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)